### PR TITLE
Track target

### DIFF
--- a/Bindings.xml
+++ b/Bindings.xml
@@ -12,42 +12,42 @@
 		end
 	</Binding>
 	<Binding name="BCTM_BINDING_FIND_HERBS" runOnUp="false">
-		bcTM_KeyBindingSpellCast(BCTM_TEXT_FIND_HERBS);
+		bcTM_KeyBindingSpellCast(BINDING_NAME_BCTM_BINDING_FIND_HERBS);
 	</Binding>
 	<Binding name="BCTM_BINDING_FIND_MINERALS" runOnUp="false">
-		bcTM_KeyBindingSpellCast(BCTM_TEXT_FIND_MINERALS);
+		bcTM_KeyBindingSpellCast(BINDING_NAME_BCTM_BINDING_FIND_MINERALS);
 	</Binding>
 	<Binding name="BCTM_BINDING_FIND_TREASURE" runOnUp="false">
-		bcTM_KeyBindingSpellCast(BCTM_TEXT_FIND_TREASURE);
+		bcTM_KeyBindingSpellCast(BINDING_NAME_BCTM_BINDING_FIND_TREASURE);
 	</Binding>
 	<Binding name="BCTM_BINDING_TRACK_BEASTS" runOnUp="false">
-		bcTM_KeyBindingSpellCast(BCTM_TEXT_TRACK_BEASTS);
+		bcTM_KeyBindingSpellCast(BINDING_NAME_BCTM_BINDING_TRACK_BEASTS);
 	</Binding>
 	<Binding name="BCTM_BINDING_TRACK_HUMANOIDS" runOnUp="false">
-		bcTM_KeyBindingSpellCast(BCTM_TEXT_TRACK_HUMANOIDS);
+		bcTM_KeyBindingSpellCast(BINDING_NAME_BCTM_BINDING_TRACK_HUMANOIDS);
 	</Binding>
 	<Binding name="BCTM_BINDING_TRACK_HIDDEN" runOnUp="false">
-		bcTM_KeyBindingSpellCast(BCTM_TEXT_TRACK_HIDDEN);
+		bcTM_KeyBindingSpellCast(BINDING_NAME_BCTM_BINDING_TRACK_HIDDEN);
 	</Binding>
 	<Binding name="BCTM_BINDING_TRACK_ELEMENTALS" runOnUp="false">
-		bcTM_KeyBindingSpellCast(BCTM_TEXT_TRACK_ELEMENTALS);
+		bcTM_KeyBindingSpellCast(BINDING_NAME_BCTM_BINDING_TRACK_ELEMENTALS);
 	</Binding>
 	<Binding name="BCTM_BINDING_TRACK_UNDEAD" runOnUp="false">
-		bcTM_KeyBindingSpellCast(BCTM_TEXT_TRACK_UNDEAD);
+		bcTM_KeyBindingSpellCast(BINDING_NAME_BCTM_BINDING_TRACK_UNDEAD);
 	</Binding>
 	<Binding name="BCTM_BINDING_TRACK_DEMONS" runOnUp="false">
-		bcTM_KeyBindingSpellCast(BCTM_TEXT_TRACK_DEMONS);
+		bcTM_KeyBindingSpellCast(BINDING_NAME_BCTM_BINDING_TRACK_DEMONS);
 	</Binding>
 	<Binding name="BCTM_BINDING_TRACK_GIANTS" runOnUp="false">
-		bcTM_KeyBindingSpellCast(BCTM_TEXT_TRACK_GIANTS);
+		bcTM_KeyBindingSpellCast(BINDING_NAME_BCTM_BINDING_TRACK_GIANTS);
 	</Binding>
 	<Binding name="BCTM_BINDING_TRACK_DRAGONKIN" runOnUp="false">
-		bcTM_KeyBindingSpellCast(BCTM_TEXT_TRACK_DRAGONKIN);
+		bcTM_KeyBindingSpellCast(BINDING_NAME_BCTM_BINDING_TRACK_DRAGONKIN);
 	</Binding>
 	<Binding name="BCTM_BINDING_SENSE_UNDEAD" runOnUp="false">
-		bcTM_KeyBindingSpellCast(BCTM_TEXT_SENSE_UNDEAD);
+		bcTM_KeyBindingSpellCast(BINDING_NAME_BCTM_BINDING_SENSE_UNDEAD);
 	</Binding>
 	<Binding name="BCTM_BINDING_SENSE_DEMONS" runOnUp="false">
-		bcTM_KeyBindingSpellCast(BCTM_TEXT_SENSE_DEMONS);
+		bcTM_KeyBindingSpellCast(BINDING_NAME_BCTM_BINDING_SENSE_DEMONS);
 	</Binding>
 </Bindings>

--- a/ReadMe.html
+++ b/ReadMe.html
@@ -1,185 +1,233 @@
 <html>
-<head>
-<title>BCUI Tracking Menu</title>
-<style>
-.text { font-family: Arial; font-size: 10pt; }
-.content { font-family: Arial; font-size: 10pt; }
-.copyright { font-family: Arial; font-size: 8pt; color: #B0B0B0; }
-a { font-family: Arial; font-size: 10pt; }
-p { font-family: Arial; font-size: 10pt; }
-li { font-family: Arial; font-size: 10pt; }
-</style>
-</head>
-<body bgcolor="#FFFFFF">
-
-<p><b>Tracking Menu</b> - Replaces the tracking icon on the minimap with an
-icon that has a popup menu that allows you to choose which tracking ability to activate.
-The menu is displayed when you mouse over the icon and is hidden when your mouse is no
-longer over the icon or the menu. The list of abilities in the menu is automatically
-populated* with the tracking abilities available to your character, and should update
-when you aquire new tracking abilities.
-<a class="content" href="http://www.bizarreconcepts.com/wow">Web Site</a></p>
-
-<p><b>Usage</b></p>
-<p><b>/bctm_report</b><br>
-Returns all of the localized strings used by the mod.  Mainly for debugging purposes.</p>
-<p><b>/bctm_showmenu</b><br>
-Shows the tracking menu centered under the cursor.</p>
-<p><b>/bctm_hidemenu</b><br>
-Hides the tracking menu.</p>
-<p><b>/bctm_getloc</b><br>
-Prints out the current location of the cursor on the screen.  This is meant to be used along with bcTM_ShowMenu() function</p>
-<p><b>/bctm_showoptions</b><br>
-Shows the option window.</p>
-<p><b>/bctm_hideoptions</b><br>
-Hides the option window.</p>
-<p><b>/script bcTM_ShowMenu(x, y, anchor);</b><br>
-Shows the tracking menu at the specified location, using the specified anchor point.
-Valid anchor points are: 'topright', 'topleft', 'bottomright', 'bottomleft', 'center' (default)<br><br>
-Example:  /script bcTM_ShowMenu(400, 300, 'topright');
-
-<p><b>Credits</b></p>
-<ul>
-	<li>Thanks to Malecandra for helping come up with this idea in the first place.</li>
-	<li>Big thanks to Jet for localizing all of the strings to French and doing most (if not all) of the code changes to hook that up.</li>
-	<li>The bcTM_pairsByKeys() function was taken from the LUA reference available at <a href="http://www.lua.org/pil/index.html">http://www.lua.org/pil/index.html</a>.</li>
-	<li>Thanks to Markus for localizing the strings to German and clueing me in to the escape codes for the different characters.</li>
-	<li>The idea for the positioning slider came from a discussion with Malecandra about how Cosmos allows the user to reposition its side bars.</li>
-	<li>Thanks to Astus for laying the ground work for the "blink while inactive" and "hide while dead" functionality.</li>
-</ul>
-
-<p><b>Revision History</b></p>
-
-<p>08/03/2005 v1.39</p>
-<ul>
-	<li>Modified the way the mod was saving it's variables.  Using a single table now to make things easier to deal with.</li>
-	<li>Added key bindings for the individual abilities.  Just go to the regular Key Bindings window.  They'll show up under the BCUI Tracking Menu section.</li>
-	<li>New interface number.</li>
-	<li>Updated localization strings.</li>
-	<li>Updated ReadMe.html</li>
-</ul>
-
-<p>06/20/2005 v1.34</p>
-<ul>
-	<li>Updated localization strings.</li>
-	<li>New interface number.</li>
-</ul>
-
-<p>04/05/2005 v1.32</p>
-<ul>
-	<li>Tweaked French localization. (Thanks Islorgris)</li>
-	<li>Tweaked German localization. (Thanks Alexspeed)</li>
-</ul>
-
-<p>03/30/2005 v1.30</p>
-<ul>
-	<li>Slight change to make the Tracking Menu hide the Aspect Menu if necessary.</li>
-	<li>Updated German localization.  (Thanks Ghandi)</li>
-</ul>
-
-<p>03/29/2005 v1.28</p>
-<ul>
-	<li>Modified bcTM_ShowMenu().  It now takes parameters for the location and anchor point to show the menu:
-	<br><br>
-	Macro example: /script bcTM_ShowMenu(x, y, 'anchor');
-	<br><br>
-	x, y = location returned from /bctm_getloc<br>
-	anchor = the point of the menu to set at the given location. Possible values: 'topright', 'topleft', 'bottomright', 'bottomleft', 'center' (default)
-	</li>
-	<li>Added /bctm_getloc.  It prints out the current location of the cursor on the screen.  This is meant to be used along with /bctm_showmenu.</li>
-	<li>Fixed the issue with the frameStrata being too high for the icon.  It should no longer overlap bag contents when they're open.</li>
-	<li>Added the functionality to allow the icon to blink if there is no tracking ability currently active. (Credit due to Astus for the idea and groundwork)</li>
-	<li>Added the functionality to allow the icon to hide while the player is dead. (Credit due to Astus for the idea and groundwork)</li>
-	<li>New interface number.</li>
-	<li>Various other code tweaks.</li>
-</ul>
-
-<p>02/18/2005 v1.21</p>
-<ul>
-	<li>Found that I wasn't using the localized tooltip text.  Doh!  Fixed.</li>
-	<li>Added a UI configuration panel with various options for showing/hiding the menu as well as a slider
-	you can use to set the position of the icon around the border of the minimap.  To open the options
-	panel, open the menu, then click on Options at the top.
+	<head>
+		<title>BCUI Tracking Menu</title>
+		<style>
+			.text {
+				font-family: Arial;
+				font-size: 10pt;
+			}
+			
+			.content {
+				font-family: Arial;
+				font-size: 10pt;
+			}
+			
+			.copyright {
+				font-family: Arial;
+				font-size: 8pt;
+				color: #B0B0B0;
+			}
+			
+			a {
+				font-family: Arial;
+				font-size: 10pt;
+			}
+			
+			p {
+				font-family: Arial;
+				font-size: 10pt;
+			}
+			
+			li {
+				font-family: Arial;
+				font-size: 10pt;
+			}
+		</style>
+	</head>
+	
+	<body bgcolor="#FFFFFF">
+		<p><strong>Tracking Menu</strong> - Replaces the tracking icon on the minimap with an
+			icon that has a popup menu that allows you to choose which tracking ability to activate.
+			The menu is displayed when you mouse over the icon and is hidden when your mouse is no
+			longer over the icon or the menu. The list of abilities in the menu is automatically
+			populated* with the tracking abilities available to your character, and should update
+			when you aquire new tracking abilities.
+		</p>
+		
+		<p><strong>Usage</strong></p>
+		<p><strong>/bctm_report</strong><br/>
+			Returns all of the localized strings used by the mod. Mainly for debugging purposes.</p>
+		<p><strong>/bctm_showmenu</strong><br/>
+			Shows the tracking menu centered under the cursor.</p>
+		<p><strong>/bctm_hidemenu</strong><br/>
+			Hides the tracking menu.</p>
+		<p><strong>/bctm_getloc</strong><br/>
+			Prints out the current location of the cursor on the screen. This is meant to be used along with bcTM_ShowMenu()
+			function</p>
+		<p><strong>/bctm_showoptions</strong><br/>
+			Shows the option window.</p>
+		<p><strong>/bctm_hideoptions</strong><br/>
+			Hides the option window.</p>
+		<p><strong>/script bcTM_ShowMenu(x, y, anchor);</strong><br/>
+			Shows the tracking menu at the specified location, using the specified anchor point.
+			Valid anchor points are: 'topright', 'topleft', 'bottomright', 'bottomleft', 'center' (default)<br/><br/>
+			Example: /script bcTM_ShowMenu(400, 300, 'topright');</p>
+		<p><strong>/bctm_tracktarget</strong><br/>
+			Casts the tracking ability corresponding to the target's creature type (if available).</p>
+		<p><strong>Credits</strong></p>
 		<ul>
-			<li>Show/Hide on mouse over/out.</li>
-			<li>Show/Hide on left clicking the icon.</li>
-			<li>Show/Hide on button press.  Requires you to bind a key through the default keybindings interface to activate.</li>
-			<li>Hide on spell cast.  Hides the menu when you click on a button to activate a tracking ability.</li>
+			<li>Thanks to Malecandra for helping come up with this idea in the first place.</li>
+			<li>Big thanks to Jet for localizing all of the strings to French and doing most (if not all) of the code
+				changes to hook that up.</li>
+			<li>The bcTM_pairsByKeys() function was taken from the LUA reference available at <a
+					href="http://www.lua.org/pil/index.html">http://www.lua.org/pil/index.html</a>.</li>
+			<li>Thanks to Markus for localizing the strings to German and clueing me in to the escape codes for the
+				different characters.</li>
+			<li>The idea for the positioning slider came from a discussion with Malecandra about how Cosmos allows the user
+				to reposition its side bars.</li>
+			<li>Thanks to Astus for laying the ground work for the "blink while inactive" and "hide while dead"
+				functionality.</li>
+				to reposition its side bars.</li>
+			<li>Ttang Oul - added tracking target's type.</li>
 		</ul>
-	</li>
-	<li>Added the following slash commands:
+		
+		<p><strong>Revision History</strong></p>
+		
+		<p>2025-02-05 v1.40</p>
 		<ul>
-			<li>/bctm_showmenu - Shows the menu centered under the mouse.</li>
-			<li>/bctm_hidemenu - Hides the menu.</li>
-			<li>/bctm_showoptions - Shows the configuration options panel.</li>
-			<li>/bctm_hideoptions - Hides the configuration options panel.</li>
+			<li>Added a command to track the target's creature type.
+			<li>New interface number.</li>
+			<li>Updated localization strings.</li>
+			<li>Updated ReadMe.html</li>
 		</ul>
-	</li>
-	<li>Modified the /bctm_report command to return all localized strings, not just the ones being looked for
-	in the spell book.</li>
-	<li>Added a keybinding that allows you to bind a key that, when pressed, will show the popup menu
-	centered under the mouse if it's not currently visible, and hide it if it is.  Note that the
-	"Show on button press" and/or "Hide on button press" options must be checked in the configuration
-	panel for this to work.</li>
-	<li>Was made aware of a bug that the menu would still list a tracking ability that you had unlearned during the
-	current play session.  Added code to reset the available abilities when the menu was re-initialized.</li>
-	<li>Noticed that the size of the menu was a bit off when the list got longer.  Tweaked a few values to try
-	to keep it consistant.</li>
-</ul>
-
-<p>02/01/2005 v1.14</p>
-<ul>
-	<li>Added German localization strings.</li>
-	<li>Tweaked the French localization strings.</li>
-	<li>Added version numbers.</li>
-	<li>Added the /bctm_report command to list out the current values being searched for in the spellbook.
-	Mainly a debugging tool.</li>
-</ul>
-
-<p>01/23/2005 v1.10</p>
-<ul>
-	<li>I think I've fixed a display problem that I introduced with the "don't show the icon when
-	you don't have any tracking abilities" code.  Please let me know if you run into any other
-	oddities while using the mod.</li>
-</ul>
-
-<p>01/15/2005 v1.09</p>
-<ul>
-	<li>Displayed strings are now localized to English and French.  If anyone out there wishes to
-	translate them into another language, just send me the text and I'll get it hooked up.</li>
-	<li>The list of abilities on the menu is now sorted alphabetically.  If other sorting/grouping
-	options are desired, let me know and I'll see what I can do.</li>
-	<li>The icon in the minimap cluster will no longer show if no tracking abilities are available to
-	the current character.</li>
-	<li>Fixed a nil reference if the MiniMapTrackingFrame was hidden for some reason, as well as
-	a few other minor code changes and optimizations.</li>
-	<li>Added Sense Demons to the list of abilities to check for.</li>
-</ul>
-
-<p>01/07/2004 v1.04</p>
-<ul>
-	<li>Fix: The tracking menu should no longer crash the game client when right-clicked when no
-	tracking abilities were active.  Evidently, calling CancelTrackingBuff() with no active
-	tracking ability causes problems.  Thanks go out to Brent and Amberly for helping track
-	this down.</li>
-	<li>Added more verbose comments throughout the code.</li>
-</ul>
-
-<p>12/??/2004 v1.02</p>
-<ul>
-	<li>Minor redesign to better accomodate other AddOns.
-	<ul>
-		<li>Instead of adding an additional icon to the minimap cluster, changed it to replace the
-		existing tracking icon.</li>
-		<li>Made the icon respond to mouse-over events instead of right-click events to display
-		the menu.</li>
-	</ul>
-</ul>
-
-<p>12/??/2004 v1.0</p>
-<ul>
-	<li>Initial release.</li>
-</ul>
-
-</body>
+		
+		<p>2005-08-03 v1.39</p>
+		<ul>
+			<li>Modified the way the mod was saving it's variables. Using a single table now to make things easier to deal
+				with.</li>
+			<li>Added key bindings for the individual abilities. Just go to the regular Key Bindings window. They'll show up
+				under the BCUI Tracking Menu section.</li>
+			<li>New interface number.</li>
+			<li>Updated localization strings.</li>
+			<li>Updated ReadMe.html</li>
+		</ul>
+		
+		<p>2005-06-20 v1.34</p>
+		<ul>
+			<li>Updated localization strings.</li>
+			<li>New interface number.</li>
+		</ul>
+		
+		<p>2005-04-05 v1.32</p>
+		<ul>
+			<li>Tweaked French localization. (Thanks Islorgris)</li>
+			<li>Tweaked German localization. (Thanks Alexspeed)</li>
+		</ul>
+		
+		<p>2005-03-30 v1.30</p>
+		<ul>
+			<li>Slight change to make the Tracking Menu hide the Aspect Menu if necessary.</li>
+			<li>Updated German localization. (Thanks Ghandi)</li>
+		</ul>
+		
+		<p>2005-03-29 v1.28</p>
+		<ul>
+			<li>Modified bcTM_ShowMenu(). It now takes parameters for the location and anchor point to show the menu:
+				<br/><br/>
+				Macro example: /script bcTM_ShowMenu(x, y, 'anchor');
+				<br/><br/>
+				x, y = location returned from /bctm_getloc<br/>
+				anchor = the point of the menu to set at the given location. Possible values: 'topright', 'topleft',
+				'bottomright', 'bottomleft', 'center' (default)
+			</li>
+			<li>Added /bctm_getloc. It prints out the current location of the cursor on the screen. This is meant to be used
+				along with /bctm_showmenu.</li>
+			<li>Fixed the issue with the frameStrata being too high for the icon. It should no longer overlap bag contents
+				when they're open.</li>
+			<li>Added the functionality to allow the icon to blink if there is no tracking ability currently active. (Credit
+				due to Astus for the idea and groundwork)</li>
+			<li>Added the functionality to allow the icon to hide while the player is dead. (Credit due to Astus for the
+				idea and groundwork)</li>
+			<li>New interface number.</li>
+			<li>Various other code tweaks.</li>
+		</ul>
+		
+		<p>2005-02-18 v1.21</p>
+		<ul>
+			<li>Found that I wasn't using the localized tooltip text. Doh! Fixed.</li>
+			<li>Added a UI configuration panel with various options for showing/hiding the menu as well as a slider
+				you can use to set the position of the icon around the border of the minimap. To open the options
+				panel, open the menu, then click on Options at the top.
+				<ul>
+					<li>Show/Hide on mouse over/out.</li>
+					<li>Show/Hide on left clicking the icon.</li>
+					<li>Show/Hide on button press. Requires you to bind a key through the default keybindings interface to
+						activate.</li>
+					<li>Hide on spell cast. Hides the menu when you click on a button to activate a tracking ability.</li>
+				</ul>
+			</li>
+			<li>Added the following slash commands:
+				<ul>
+					<li>/bctm_showmenu - Shows the menu centered under the mouse.</li>
+					<li>/bctm_hidemenu - Hides the menu.</li>
+					<li>/bctm_showoptions - Shows the configuration options panel.</li>
+					<li>/bctm_hideoptions - Hides the configuration options panel.</li>
+				</ul>
+			</li>
+			<li>Modified the /bctm_report command to return all localized strings, not just the ones being looked for
+				in the spell book.</li>
+			<li>Added a keybinding that allows you to bind a key that, when pressed, will show the popup menu
+				centered under the mouse if it's not currently visible, and hide it if it is. Note that the
+				"Show on button press" and/or "Hide on button press" options must be checked in the configuration
+				panel for this to work.</li>
+			<li>Was made aware of a bug that the menu would still list a tracking ability that you had unlearned during the
+				current play session. Added code to reset the available abilities when the menu was re-initialized.</li>
+			<li>Noticed that the size of the menu was a bit off when the list got longer. Tweaked a few values to try
+				to keep it consistant.</li>
+		</ul>
+		
+		<p>2005-02-01 v1.14</p>
+		<ul>
+			<li>Added German localization strings.</li>
+			<li>Tweaked the French localization strings.</li>
+			<li>Added version numbers.</li>
+			<li>Added the /bctm_report command to list out the current values being searched for in the spellbook.
+				Mainly a debugging tool.</li>
+		</ul>
+		
+		<p>2005-01-23 v1.10</p>
+		<ul>
+			<li>I think I've fixed a display problem that I introduced with the "don't show the icon when
+				you don't have any tracking abilities" code. Please let me know if you run into any other
+				oddities while using the mod.</li>
+		</ul>
+		
+		<p>2005-01-15 v1.09</p>
+		<ul>
+			<li>Displayed strings are now localized to English and French. If anyone out there wishes to
+				translate them into another language, just send me the text and I'll get it hooked up.</li>
+			<li>The list of abilities on the menu is now sorted alphabetically. If other sorting/grouping
+				options are desired, let me know and I'll see what I can do.</li>
+			<li>The icon in the minimap cluster will no longer show if no tracking abilities are available to
+				the current character.</li>
+			<li>Fixed a nil reference if the MiniMapTrackingFrame was hidden for some reason, as well as
+				a few other minor code changes and optimizations.</li>
+			<li>Added Sense Demons to the list of abilities to check for.</li>
+		</ul>
+		
+		<p>2005-01-07 v1.04</p>
+		<ul>
+			<li>Fix: The tracking menu should no longer crash the game client when right-clicked when no
+				tracking abilities were active. Evidently, calling CancelTrackingBuff() with no active
+				tracking ability causes problems. Thanks go out to Brent and Amberly for helping track
+				this down.</li>
+			<li>Added more verbose comments throughout the code.</li>
+		</ul>
+		
+		<p>2004-12-XX v1.02</p>
+		<ul>
+			<li>Minor redesign to better accomodate other AddOns.
+				<ul>
+					<li>Instead of adding an additional icon to the minimap cluster, changed it to replace the
+						existing tracking icon.</li>
+					<li>Made the icon respond to mouse-over events instead of right-click events to display
+						the menu.</li>
+				</ul>
+		</ul>
+		
+		<p>2004-12-XX v1.0</p>
+		<ul>
+			<li>Initial release.</li>
+		</ul>
+	</body>
 </html>

--- a/bc_TrackingMenu.lua
+++ b/bc_TrackingMenu.lua
@@ -3,7 +3,6 @@
 See the ReadMe.txt file for more information.
 
 ]]
-
 bcTM_Config = {}
 bcTM_Config.ShowOnMouse = 1
 bcTM_Config.ShowOnClick = 0
@@ -25,7 +24,7 @@ BCTM_NUM_BUTTONS = 12;
 BCTM_BORDER_WIDTH = 15;
 BCTM_BUTTON_HEIGHT = 12;
 
-BCTM_BLINK_CHECK_INTERVAL = 2;    -- how often, in seconds, to check to see if we need to be blinking, or hiding the icon while dead.
+BCTM_BLINK_CHECK_INTERVAL = 2; -- how often, in seconds, to check to see if we need to be blinking, or hiding the icon while dead.
 
 bcTM_BlinkLastChecked = 0;
 bcTM_BlinkEnabled = false;
@@ -33,21 +32,37 @@ bcTM_BlinkReset = true;
 bcTM_FadeOut = true;
 bcTM_CurrentBlinkDelay = 0;
 
+
+bcTM_CreatureTypeToAvailableTrackingAbilities = {}
+
+bcTM_TrackingAbilityToCreatureType = {
+	[BINDING_NAME_BCTM_BINDING_SENSE_DEMONS] = BINDING_NAME_BCTM_BINDING_TYPE_DEMON,
+	[BINDING_NAME_BCTM_BINDING_SENSE_UNDEAD] = BINDING_NAME_BCTM_BINDING_TYPE_UNDEAD,
+	[BINDING_NAME_BCTM_BINDING_TRACK_BEASTS] = BINDING_NAME_BCTM_BINDING_TYPE_BEAST,
+	[BINDING_NAME_BCTM_BINDING_TRACK_DEMONS] = BINDING_NAME_BCTM_BINDING_TYPE_DEMON,
+	[BINDING_NAME_BCTM_BINDING_TRACK_DRAGONKIN] = BINDING_NAME_BCTM_BINDING_TYPE_DRAGONKIN,
+	[BINDING_NAME_BCTM_BINDING_TRACK_ELEMENTALS] = BINDING_NAME_BCTM_BINDING_TYPE_ELEMENTAL,
+	[BINDING_NAME_BCTM_BINDING_TRACK_GIANTS] = BINDING_NAME_BCTM_BINDING_TYPE_GIANT,
+	[BINDING_NAME_BCTM_BINDING_TRACK_HUMANOIDS] = BINDING_NAME_BCTM_BINDING_TYPE_HUMANOID,
+	[BINDING_NAME_BCTM_BINDING_TRACK_UNDEAD] = BINDING_NAME_BCTM_BINDING_TYPE_UNDEAD,
+}
+
+
 -- List of tracking abilities to look for.
 bcTM_TrackingAbilities = {
-	[BCTM_TEXT_FIND_HERBS] = 0,
-	[BCTM_TEXT_FIND_MINERALS] = 0,
-	[BCTM_TEXT_FIND_TREASURE] = 0,
-	[BCTM_TEXT_TRACK_BEASTS] = 0,
-	[BCTM_TEXT_TRACK_HUMANOIDS] = 0,
-	[BCTM_TEXT_TRACK_HIDDEN] = 0,
-	[BCTM_TEXT_TRACK_ELEMENTALS] = 0,
-	[BCTM_TEXT_TRACK_UNDEAD] = 0,
-	[BCTM_TEXT_TRACK_DEMONS] = 0,
-	[BCTM_TEXT_TRACK_GIANTS] = 0,
-	[BCTM_TEXT_TRACK_DRAGONKIN] = 0,
-	[BCTM_TEXT_SENSE_UNDEAD] = 0,
-	[BCTM_TEXT_SENSE_DEMONS] = 0,
+	[BINDING_NAME_BCTM_BINDING_FIND_HERBS] = 0,
+	[BINDING_NAME_BCTM_BINDING_FIND_MINERALS] = 0,
+	[BINDING_NAME_BCTM_BINDING_FIND_TREASURE] = 0,
+	[BINDING_NAME_BCTM_BINDING_TRACK_BEASTS] = 0,
+	[BINDING_NAME_BCTM_BINDING_TRACK_HUMANOIDS] = 0,
+	[BINDING_NAME_BCTM_BINDING_TRACK_HIDDEN] = 0,
+	[BINDING_NAME_BCTM_BINDING_TRACK_ELEMENTALS] = 0,
+	[BINDING_NAME_BCTM_BINDING_TRACK_UNDEAD] = 0,
+	[BINDING_NAME_BCTM_BINDING_TRACK_DEMONS] = 0,
+	[BINDING_NAME_BCTM_BINDING_TRACK_GIANTS] = 0,
+	[BINDING_NAME_BCTM_BINDING_TRACK_DRAGONKIN] = 0,
+	[BINDING_NAME_BCTM_BINDING_SENSE_UNDEAD] = 0,
+	[BINDING_NAME_BCTM_BINDING_SENSE_DEMONS] = 0,
 }
 
 -- ******************************************************************
@@ -61,19 +76,26 @@ end
 function bcTM_Report()
 	bcWrite(BCTM_TEXT_TITLE_BUTTON);
 	bcWrite(BCTM_TEXT_TOOLTIP);
-	bcWrite(BCTM_TEXT_FIND_HERBS);
-	bcWrite(BCTM_TEXT_FIND_MINERALS);
-	bcWrite(BCTM_TEXT_FIND_TREASURE);
-	bcWrite(BCTM_TEXT_TRACK_BEASTS);
-	bcWrite(BCTM_TEXT_TRACK_HUMANOIDS);
-	bcWrite(BCTM_TEXT_TRACK_HIDDEN);
-	bcWrite(BCTM_TEXT_TRACK_ELEMENTALS);
-	bcWrite(BCTM_TEXT_TRACK_UNDEAD);
-	bcWrite(BCTM_TEXT_TRACK_DEMONS);
-	bcWrite(BCTM_TEXT_TRACK_GIANTS);
-	bcWrite(BCTM_TEXT_TRACK_DRAGONKIN);
-	bcWrite(BCTM_TEXT_SENSE_UNDEAD);
-	bcWrite(BCTM_TEXT_SENSE_DEMONS);
+	bcWrite(BINDING_NAME_BCTM_BINDING_FIND_HERBS);
+	bcWrite(BINDING_NAME_BCTM_BINDING_FIND_MINERALS);
+	bcWrite(BINDING_NAME_BCTM_BINDING_FIND_TREASURE);
+	bcWrite(BINDING_NAME_BCTM_BINDING_SENSE_DEMONS);
+	bcWrite(BINDING_NAME_BCTM_BINDING_SENSE_UNDEAD);
+	bcWrite(BINDING_NAME_BCTM_BINDING_TRACK_BEASTS);
+	bcWrite(BINDING_NAME_BCTM_BINDING_TRACK_DEMONS);
+	bcWrite(BINDING_NAME_BCTM_BINDING_TRACK_DRAGONKIN);
+	bcWrite(BINDING_NAME_BCTM_BINDING_TRACK_ELEMENTALS);
+	bcWrite(BINDING_NAME_BCTM_BINDING_TRACK_GIANTS);
+	bcWrite(BINDING_NAME_BCTM_BINDING_TRACK_HIDDEN);
+	bcWrite(BINDING_NAME_BCTM_BINDING_TRACK_HUMANOIDS);
+	bcWrite(BINDING_NAME_BCTM_BINDING_TRACK_UNDEAD);
+	bcWrite(BINDING_NAME_BCTM_BINDING_TYPE_BEAST);
+	bcWrite(BINDING_NAME_BCTM_BINDING_TYPE_DEMON);
+	bcWrite(BINDING_NAME_BCTM_BINDING_TYPE_DRAGONKIN);
+	bcWrite(BINDING_NAME_BCTM_BINDING_TYPE_ELEMENTAL);
+	bcWrite(BINDING_NAME_BCTM_BINDING_TYPE_GIANT);
+	bcWrite(BINDING_NAME_BCTM_BINDING_TYPE_HUMANOID);
+	bcWrite(BINDING_NAME_BCTM_BINDING_TYPE_UNDEAD);
 	bcWrite(BCTM_TEXT_CONFIG_TITLE);
 	bcWrite(BCTM_TEXT_SHOWONMOUSE);
 	bcWrite(BCTM_TEXT_HIDEONMOUSE);
@@ -110,23 +132,27 @@ function bcTM_OnLoad()
 	-- Create the slash command to output the cursor position.
 	SlashCmdList["BCTM_GETLOC"] = bcTM_GetLocation;
 	SLASH_BCTM_GETLOC1 = "/bctm_getloc";
-
+	
 	-- Create the slash commands to show/hide the options window.
 	SlashCmdList["BCTM_SHOWOPTIONS"] = bcTM_ShowOptions;
 	SLASH_BCTM_SHOWOPTIONS1 = "/bctm_showoptions";
 	SlashCmdList["BCTM_HIDEOPTIONS"] = bcTM_HideOptions;
 	SLASH_BCTM_HIDEOPTIONS1 = "/bctm_hideoptions";
 	
-	-- Let the user know the mod loaded.
-	if ( DEFAULT_CHAT_FRAME ) then 
-		bcWrite("BC Tracking Menu loaded");
-	end
+	-- Create the slash commands to track the target's type.
+	SlashCmdList["BCTM_TRACKTARGET"] = bcTM_TrackTarget;
+	SLASH_BCTM_TRACKTARGET1 = "/bctm_tracktarget";
+
+-- Let the user know the mod loaded.
+-- if ( DEFAULT_CHAT_FRAME ) then
+-- bcWrite("BC Tracking Menu loaded");
+-- end
 end
 
 -- ******************************************************************
 function bcTM_GetLocation()
 	local x, y = GetCursorPosition();
-	bcWrite("Cursor location: "..x..", "..y);
+	bcWrite("Cursor location: " .. x .. ", " .. y);
 end
 
 -- ******************************************************************
@@ -135,12 +161,12 @@ function bcTM_ShowMenu(x, y, anchor)
 		bcTM_Hide();
 		return;
 	end
-
+	
 	if (x == nil or y == nil) then
 		-- Get the cursor position.  Point is relative to the bottom left corner of the screen.
 		x, y = GetCursorPosition();
 	end
-
+	
 	if (anchor == nil) then
 		anchor = "center";
 	end
@@ -148,7 +174,7 @@ function bcTM_ShowMenu(x, y, anchor)
 	-- Adjust for the UI scale.
 	x = x / UIParent:GetScale();
 	y = y / UIParent:GetScale();
-
+	
 	-- Adjust for the height/width/anchor of the menu.
 	if (anchor == "topright") then
 		x = x - bcTM_Popup:GetWidth();
@@ -159,12 +185,12 @@ function bcTM_ShowMenu(x, y, anchor)
 		x = x - bcTM_Popup:GetWidth();
 	elseif (anchor == "bottomleft") then
 		-- do nothing.
-	else
+		else
 		-- anchor is either "center" or not a valid value.
 		x = x - bcTM_Popup:GetWidth() / 2;
 		y = y - bcTM_Popup:GetHeight() / 2;
 	end
-
+	
 	-- Clear the current anchor point, and set it to be centered under the mouse.
 	bcTM_Popup:ClearAllPoints();
 	bcTM_Popup:SetPoint("BOTTOMLEFT", "UIParent", "BOTTOMLEFT", x, y);
@@ -180,7 +206,6 @@ end
 function bcTM_OnEvent()
 	if (event == "PLAYER_AURAS_CHANGED") then
 		-- When the user changes their active tracking ability, do the following.
-		
 		-- Hide the default tracking icon.
 		if (MiniMapTrackingFrame) then
 			MiniMapTrackingFrame:Hide();
@@ -188,7 +213,7 @@ function bcTM_OnEvent()
 		
 		-- Get the icon for the currently active tracking ability.
 		local icon = GetTrackingTexture();
-		if ( icon ) then
+		if (icon) then
 			-- Set our icon to match the active ability.
 			bcTM_IconTexture:SetTexture(icon);
 		else
@@ -234,25 +259,32 @@ function bcTM_InitializeMenu()
 			bcTM_TrackingAbilities[spellName] = 0
 		end
 	end
-
+	
 	-- Calculate the total number of spells known by scanning the spellbook.
 	local numTotalSpells = 0;
-	for i=1, MAX_SKILLLINE_TABS do
+	for i = 1, MAX_SKILLLINE_TABS do
 		local name, texture, offset, numSpells = GetSpellTabInfo(i);
 		if (name) then
 			numTotalSpells = numTotalSpells + numSpells
 		end
 	end
-
+	
 	bcTM_IconFrame.haveAbilities = false;
 	
 	-- Find the tracking abilities available.
-	for i=1, numTotalSpells do
+	for i = 1, numTotalSpells do
 		local spellName, subSpellName = GetSpellName(i, SpellBookFrame.bookType);
 		if (spellName) then
 			if (bcTM_TrackingAbilities[spellName]) then
 				bcTM_IconFrame.haveAbilities = true;
 				bcTM_TrackingAbilities[spellName] = i
+				local creatureType = bcTM_TrackingAbilityToCreatureType[spellName]
+				if creatureType then
+					if bcTM_CreatureTypeToAvailableTrackingAbilities[creatureType] == nil then
+						bcTM_CreatureTypeToAvailableTrackingAbilities[creatureType] = {}
+					end
+					table.insert(bcTM_CreatureTypeToAvailableTrackingAbilities[creatureType], spellName)
+				end
 			end
 		end
 	end
@@ -260,14 +292,14 @@ function bcTM_InitializeMenu()
 	if (bcTM_IconFrame.haveAbilities) then
 		bcTM_IconFrame:Show();
 	end
-
+	
 	-- Set the text for the buttons while keeping track of how many
 	-- buttons we actually need.
 	local count = 0;
 	for spell, id in bcTM_pairsByKeys(bcTM_TrackingAbilities) do
 		if (id > 0) then
 			count = count + 1;
-			local button = getglobal("bcTM_PopupButton"..count);
+			local button = getglobal("bcTM_PopupButton" .. count);
 			button:SetText(spell);
 			button.SpellID = id;
 			button:Show();
@@ -277,26 +309,26 @@ function bcTM_InitializeMenu()
 	-- Set the width for the menu.
 	local width = bcTM_TitleButton:GetWidth();
 	for i = 1, count, 1 do
-		local button = getglobal("bcTM_PopupButton"..i);
+		local button = getglobal("bcTM_PopupButton" .. i);
 		local w = button:GetTextWidth();
 		if (w > width) then
 			width = w;
 		end
 	end
 	bcTM_Popup:SetWidth(width + 2 * BCTM_BORDER_WIDTH);
-
+	
 	-- By default, the width of the button is set to the width of the text
 	-- on the button.  Set the width of each button to the width of the
 	-- menu so that you can still click on it without being directly
 	-- over the text.
 	for i = 1, count, 1 do
-		local button = getglobal("bcTM_PopupButton"..i);
+		local button = getglobal("bcTM_PopupButton" .. i);
 		button:SetWidth(width);
 	end
-
+	
 	-- Hide the buttons we don't need.
 	for i = count + 1, BCTM_NUM_BUTTONS, 1 do
-		local button = getglobal("bcTM_PopupButton"..i);
+		local button = getglobal("bcTM_PopupButton" .. i);
 		button:Hide();
 	end
 	
@@ -306,7 +338,7 @@ end
 
 -- ******************************************************************
 function bcTM_ButtonClick()
--- Cast the selected spell.
+	-- Cast the selected spell.
 	CastSpell(this.SpellID, "spell");
 	
 	if (bcTM_Config.HideOnCast == 1) then
@@ -323,7 +355,7 @@ function bcTM_Show()
 			bcAM_Hide();
 		end
 	end
-
+	
 	bcTM_Popup:Show();
 end
 
@@ -351,7 +383,7 @@ function bcTM_OnUpdate(elapsed)
 			bcTM_Hide();
 		end
 	end
-
+	
 	bcTM_BlinkLastChecked = bcTM_BlinkLastChecked + elapsed;
 	if (bcTM_BlinkLastChecked > BCTM_BLINK_CHECK_INTERVAL) then
 		if (GetTrackingTexture() == nil and bcTM_Config.BlinkOnInactive == 1) then
@@ -359,29 +391,29 @@ function bcTM_OnUpdate(elapsed)
 		else
 			bcTM_BlinkEnabled = false;
 		end
-
+		
 		if (bcTM_Config.HideWhileDead == 1 and UnitIsDeadOrGhost("player")) then
 			bcTM_IconFrame:Hide();
 		elseif (bcTM_IconFrame.haveAbilities) then
 			bcTM_IconFrame:Show();
 		end
-
+		
 		bcTM_BlinkLastChecked = 0;
 	end
-
+	
 	if (bcTM_BlinkEnabled and bcTM_IconFrame:IsVisible()) then
 		bcTM_BlinkReset = false;
 		bcTM_CurrentBlinkDelay = bcTM_CurrentBlinkDelay + elapsed;
-
+		
 		if (bcTM_CurrentBlinkDelay > bcTM_Config.BlinkDelay) then
 			local alpha = bcTM_IconFrame:GetAlpha();
-
+			
 			if (alpha == 0 and bcTM_FadeOut) then
 				bcTM_FadeOut = false;
 			elseif (alpha == 1.0 and not bcTM_FadeOut) then
 				bcTM_FadeOut = true;
 			end
-
+			
 			if (alpha > 0 and bcTM_FadeOut) then
 				-- decrease alpha
 				alpha = alpha - (elapsed / (bcTM_Config.BlinkDuration / 2));
@@ -389,20 +421,20 @@ function bcTM_OnUpdate(elapsed)
 				-- increase alpha
 				alpha = alpha + (elapsed / (bcTM_Config.BlinkDuration / 2));
 			end
-
+			
 			if (alpha < 0) then
 				alpha = 0;
 			elseif (alpha > 1) then
 				alpha = 1.0;
 			end
-
+			
 			bcTM_IconFrame:SetAlpha(alpha);
-
+			
 			if (alpha == 1.0 and not bcTM_FadeOut) then
 				bcTM_CurrentBlinkDelay = 0;
 			end
 		end
-
+	
 	elseif (not bcTM_BlinkReset) then
 		bcTM_IconFrame:SetAlpha(1.0);
 		bcTM_CurrentBlinkDelay = 0;
@@ -416,11 +448,11 @@ function bcTM_pairsByKeys(t, f)
 	local a = {}
 	for n in pairs(t) do table.insert(a, n) end
 	table.sort(a, f)
-	local i = 0      -- iterator variable
-	local iter = function ()   -- iterator function
+	local i = 0 -- iterator variable
+	local iter = function()-- iterator function
 		i = i + 1
 		if a[i] == nil then return nil
-			else return a[i], t[a[i]]
+		else return a[i], t[a[i]]
 		end
 	end
 	return iter
@@ -431,16 +463,16 @@ function bcTM_IconFrameOnEnter()
 	-- Set the anchor point of the menu so it shows up next to the icon.
 	bcTM_Popup:ClearAllPoints();
 	bcTM_Popup:SetPoint("TOPRIGHT", "bcTM_IconFrame", "TOPLEFT");
-
+	
 	-- Set the anchor and text for the tooltip.
 	GameTooltip:SetOwner(bcTM_IconFrame, "ANCHOR_BOTTOMRIGHT");
 	local icon = GetTrackingTexture();
-	if ( icon ) then
+	if (icon) then
 		GameTooltip:SetTrackingSpell();
 	else
 		GameTooltip:SetText(BCTM_TEXT_TOOLTIP);
 	end
-
+	
 	-- Show the menu.
 	if (bcTM_Config.ShowOnMouse == 1) then
 		bcTM_Show();
@@ -465,9 +497,9 @@ end
 -- Not yet fully implemented.
 function bcTM_ButtonBindingOnLoad()
 	this:RegisterForClicks("LeftButtonUp", "RightButtonUp", "MiddleButtonUp", "Button4Up", "Button5Up");
-
+	
 	local key1 = GetBindingKey("BCTM_BINDING_TOGGLE_MENU");
-
+	
 	if (key1) then
 		this:SetText(key1);
 	else
@@ -483,15 +515,15 @@ function bcTM_ButtonBindingOnClick()
 	if (this.selected == nil) then
 		this.selected = true;
 		this:SetText("Press a key to bind");
-		
+	
 	else
 		this.selected = nil;
 		local key1, key2 = GetBindingKey("BCTM_BINDING_TOGGLE_MENU");
 		this:SetText(key1);
 	end
-
+	
 	if (key1) then
-		bcWrite("key 1 = "..key1);
+		bcWrite("key 1 = " .. key1);
 	end
 	if (key2) then
 		bcWrite("key 2");
@@ -502,5 +534,22 @@ end
 function bcTM_KeyBindingSpellCast(spellName)
 	if (bcTM_TrackingAbilities[spellName] > 0) then
 		CastSpell(bcTM_TrackingAbilities[spellName], "spell");
+	end
+end
+
+-- ******************************************************************
+function bcTM_TrackTarget()
+	if not UnitName("target") then
+		bcWrite(SPELL_FAILED_BAD_IMPLICIT_TARGETS);
+		return
+	end
+	local targetType = UnitCreatureType("target")
+	if targetType and bcTM_CreatureTypeToAvailableTrackingAbilities[targetType] then
+		for _, spell in ipairs(bcTM_CreatureTypeToAvailableTrackingAbilities[targetType]) do
+			CastSpellByName(spell)
+		end
+	else
+		bcWrite(SPELL_FAILED_NOT_KNOW);
+		return
 	end
 end

--- a/bc_TrackingMenu.toc
+++ b/bc_TrackingMenu.toc
@@ -1,11 +1,11 @@
-## Interface: 1600
-## Title: BCUI - Tracking Menu v1.39
-## Title-frFR: BCUI - Menu de Pistage v1.39
-## Title-deDE: BCUI - Tracking Menu v1.39
+## Interface: 11200
+## Title: BCUI - Tracking Menu v1.40
+## Title-frFR: BCUI - Menu de Pistage v1.40
+## Title-deDE: BCUI - Tracking Menu v1.40
 ## Notes: Replaces the tracking icon on the minimap with an icon that has a pop-up menu for tracking abilities.
 ## Notes-frFR: Remplace l'icone de pistage de la minicarte avec une icone possedant un menu pour les competences de pistage.
 ## Notes-deDE: Replaces the tracking icon on the minimap with an icon that has a pop-up menu for tracking abilities.
-## OptionalDeps:
+## OptionalDeps: 
 ## Dependencies: 
 ## SavedVariables: bcTM_Config
 bc_TrackingMenu.xml

--- a/localization.lua
+++ b/localization.lua
@@ -22,6 +22,14 @@ if (GetLocale() == "deDE") then
 	BINDING_NAME_BCTM_BINDING_TRACK_HIDDEN     = "Verborgenes aufsp\195\188ren";
 	BINDING_NAME_BCTM_BINDING_TRACK_HUMANOIDS  = "Humanoide aufsp\195\188ren";
 	BINDING_NAME_BCTM_BINDING_TRACK_UNDEAD     = "Untote aufsp\195\188ren";
+	BINDING_NAME_BCTM_BINDING_SENSE_UNDEAD     = "Untote Sp\195\188ren";
+	BINDING_NAME_BCTM_BINDING_TYPE_BEAST       = "Wildtier";
+	BINDING_NAME_BCTM_BINDING_TYPE_DEMON       = "D\195\164mon";
+	BINDING_NAME_BCTM_BINDING_TYPE_DRAGONKIN   = "Drachkin";
+	BINDING_NAME_BCTM_BINDING_TYPE_ELEMENTAL   = "Elementar";
+	BINDING_NAME_BCTM_BINDING_TYPE_GIANT       = "Riese";
+	BINDING_NAME_BCTM_BINDING_TYPE_HUMANOID    = "Humanoid";
+	BINDING_NAME_BCTM_BINDING_TYPE_UNDEAD      = "Untot";
 	
 	BCTM_TEXT_CONFIG_TITLE      = "Aufsp\195\188r-Men\195\188 Einstellungen";
 	BCTM_TEXT_SHOWONMOUSE       = "Bei Ber\195\188hrung zeigen";
@@ -39,20 +47,6 @@ if (GetLocale() == "deDE") then
 	BCTM_TEXT_BLINKDURATION_TIP = "Dauer einer Ein-/Ausblenden anpassen";
 	BCTM_TEXT_BLINKDELAY        = "Blinkverz\195\182gerung";
 	BCTM_TEXT_BLINKDELAY_TIP    = "Pause zwischen dem Blinken des Icons anpassen";
-	
-	BCTM_TEXT_FIND_HERBS       = "Kr\195\164utersuche";
-	BCTM_TEXT_FIND_MINERALS    = "Mineraliensuche";
-	BCTM_TEXT_FIND_TREASURE    = "Schatzsucher";
-	BCTM_TEXT_SENSE_DEMONS     = "D\195\164monen sp\195\188ren";
-	BCTM_TEXT_SENSE_UNDEAD     = "Untote Sp\195\188ren";
-	BCTM_TEXT_TRACK_BEASTS     = "Wildtiere aufsp\195\188ren";
-	BCTM_TEXT_TRACK_DEMONS     = "D\195\164monen aufsp\195\188ren";
-	BCTM_TEXT_TRACK_DRAGONKIN  = "Drachkin aufsp\195\188ren";
-	BCTM_TEXT_TRACK_ELEMENTALS = "Elementare aufsp\195\188ren";
-	BCTM_TEXT_TRACK_GIANTS     = "Riesen aufsp\195\188ren";
-	BCTM_TEXT_TRACK_HIDDEN     = "Verborgenes aufsp\195\188ren";
-	BCTM_TEXT_TRACK_HUMANOIDS  = "Humanoide aufsp\195\188ren";
-	BCTM_TEXT_TRACK_UNDEAD     = "Untote aufsp\195\188ren";
 elseif (GetLocale() == "frFR") then
 	BCTM_TEXT_TITLE_BUTTON = "Options";
 	BCTM_TEXT_TOOLTIP      = "Choisir Pistage";
@@ -72,6 +66,14 @@ elseif (GetLocale() == "frFR") then
 	BINDING_NAME_BCTM_BINDING_TRACK_HIDDEN     = "Pistage des camoufl\195\169s";
 	BINDING_NAME_BCTM_BINDING_TRACK_HUMANOIDS  = "Pistage des humano\195\175des";
 	BINDING_NAME_BCTM_BINDING_TRACK_UNDEAD     = "Pistage des morts-vivants";
+	BINDING_NAME_BCTM_BINDING_SENSE_UNDEAD     = "D\195\169tection des morts-vivants";
+	BINDING_NAME_BCTM_BINDING_TYPE_BEAST       = "B\195\170te";
+	BINDING_NAME_BCTM_BINDING_TYPE_DEMON       = "D\195\169mon";
+	BINDING_NAME_BCTM_BINDING_TYPE_DRAGONKIN   = "Draconien";
+	BINDING_NAME_BCTM_BINDING_TYPE_ELEMENTAL   = "\195\137l\195\169mentaire";
+	BINDING_NAME_BCTM_BINDING_TYPE_GIANT       = "G\195\169ant";
+	BINDING_NAME_BCTM_BINDING_TYPE_HUMANOID    = "Humano\195\175de";
+	BINDING_NAME_BCTM_BINDING_TYPE_UNDEAD      = "Mort-vivant";
 	
 	BCTM_TEXT_CONFIG_TITLE      = "Tracking Menu: Options";
 	BCTM_TEXT_SHOWONMOUSE       = "Montrer sur passage souris";
@@ -89,20 +91,6 @@ elseif (GetLocale() == "frFR") then
 	BCTM_TEXT_BLINKDURATION_TIP = "Adjusts the time it takes to fade the tracking icon in and out";
 	BCTM_TEXT_BLINKDELAY        = "Blink Delay";
 	BCTM_TEXT_BLINKDELAY_TIP    = "Adjusts the time between blinks of the icon";
-	
-	BCTM_TEXT_FIND_HERBS       = "D\195\169couverte d'herbes";
-	BCTM_TEXT_FIND_MINERALS    = "D\195\169couverte de gisements";
-	BCTM_TEXT_FIND_TREASURE    = "D\195\169couverte de tr\195\169sors";
-	BCTM_TEXT_SENSE_DEMONS     = "D\195\169tection des d\195\169mons";
-	BCTM_TEXT_SENSE_UNDEAD     = "D\195\169tection des morts-vivants";
-	BCTM_TEXT_TRACK_BEASTS     = "Pistage des b\195\170tes";
-	BCTM_TEXT_TRACK_DEMONS     = "Pistage des d\195\169mons";
-	BCTM_TEXT_TRACK_DRAGONKIN  = "Pistage des draconiens";
-	BCTM_TEXT_TRACK_ELEMENTALS = "Pistage des \195\169l\195\169mentaires"
-	BCTM_TEXT_TRACK_GIANTS     = "Pistage des g\195\169ants";
-	BCTM_TEXT_TRACK_HIDDEN     = "Pistage des camoufl\195\169s";
-	BCTM_TEXT_TRACK_HUMANOIDS  = "Pistage des humano\195\175des";
-	BCTM_TEXT_TRACK_UNDEAD     = "Pistage des morts-vivants";
 else -- English by default
 	BCTM_TEXT_TITLE_BUTTON = "Options";
 	BCTM_TEXT_TOOLTIP      = "Set Tracking";
@@ -122,6 +110,13 @@ else -- English by default
 	BINDING_NAME_BCTM_BINDING_TRACK_HIDDEN     = "Track Hidden";
 	BINDING_NAME_BCTM_BINDING_TRACK_HUMANOIDS  = "Track Humanoids";
 	BINDING_NAME_BCTM_BINDING_TRACK_UNDEAD     = "Track Undead";
+	BINDING_NAME_BCTM_BINDING_TYPE_BEAST       = "Beast";
+	BINDING_NAME_BCTM_BINDING_TYPE_DEMON       = "Demon";
+	BINDING_NAME_BCTM_BINDING_TYPE_DRAGONKIN   = "Dragonkin";
+	BINDING_NAME_BCTM_BINDING_TYPE_ELEMENTAL   = "Elemental";
+	BINDING_NAME_BCTM_BINDING_TYPE_GIANT       = "Giant";
+	BINDING_NAME_BCTM_BINDING_TYPE_HUMANOID    = "Humanoid";
+	BINDING_NAME_BCTM_BINDING_TYPE_UNDEAD      = "Undead";
 	
 	BCTM_TEXT_CONFIG_TITLE      = "Tracking Menu Options";
 	BCTM_TEXT_SHOWONMOUSE       = "Show on mouse over";
@@ -139,18 +134,4 @@ else -- English by default
 	BCTM_TEXT_BLINKDURATION_TIP = "Adjusts the time it takes to fade the tracking icon in and out";
 	BCTM_TEXT_BLINKDELAY        = "Blink Delay";
 	BCTM_TEXT_BLINKDELAY_TIP    = "Adjusts the time between blinks of the icon";
-	
-	BCTM_TEXT_FIND_HERBS       = "Find Herbs";
-	BCTM_TEXT_FIND_MINERALS    = "Find Minerals";
-	BCTM_TEXT_FIND_TREASURE    = "Find Treasure";
-	BCTM_TEXT_SENSE_DEMONS     = "Sense Demons";
-	BCTM_TEXT_SENSE_UNDEAD     = "Sense Undead";
-	BCTM_TEXT_TRACK_BEASTS     = "Track Beasts";
-	BCTM_TEXT_TRACK_DEMONS     = "Track Demons";
-	BCTM_TEXT_TRACK_DRAGONKIN  = "Track Dragonkin";
-	BCTM_TEXT_TRACK_ELEMENTALS = "Track Elementals";
-	BCTM_TEXT_TRACK_GIANTS     = "Track Giants";
-	BCTM_TEXT_TRACK_HIDDEN     = "Track Hidden";
-	BCTM_TEXT_TRACK_HUMANOIDS  = "Track Humanoids";
-	BCTM_TEXT_TRACK_UNDEAD     = "Track Undead";
 end


### PR DESCRIPTION
Added a command `/bctm_tracktarget` to track creatures of the target's type - handier than selecting the tracking manually. Useful for hunters.